### PR TITLE
chore: upgrade jackson-jq to 1.0.0-preview.20230409

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,7 @@
 {:paths
  ["src"]
  :deps
- {net.thisptr/jackson-jq                      {:mvn/version "1.0.0-preview.20220705"}
-  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.13.4.2"}}
+ {net.thisptr/jackson-jq {:mvn/version "1.0.0-preview.20230409"}}
  :aliases
  {:dev
   {:extra-paths ["dev" "classes" "test" "test/resources"]


### PR DESCRIPTION
Just an upgrade of the core dependency.

https://github.com/eiiches/jackson-jq/releases/tag/1.0.0-preview.20230409