### PR TITLE
Support queries where outputs are not 1:1 with inputs

### DIFF
--- a/cli/jq/cli.clj
+++ b/cli/jq/cli.clj
@@ -3,8 +3,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
-            [jq.api :as jq]
-            [jq.api.api-impl :as impl])
+            [jq.api :as jq])
   (:import (java.io Reader BufferedReader)))
 
 (def cli-options
@@ -29,11 +28,11 @@
     (if (seq files)
       (doseq [f files
               item (jq-processor (slurp f))]
-        (println (impl/json-node->string item)))
+        (println (jq/json-node->string item)))
       (when (.ready ^Reader *in*)
         (doseq [line (line-seq (BufferedReader. *in*))
                 item (jq-processor line)]
-          (println (impl/json-node->string item)))))))
+          (println (jq/json-node->string item)))))))
 
 (defn -main [& args]
   (let [{:keys               [options arguments errors summary]

--- a/src/jq/api.clj
+++ b/src/jq/api.clj
@@ -4,6 +4,9 @@
 
 (set! *warn-on-reflection* true)
 
+; required in common use cases, so moving out of impl space
+(def json-node->string impl/json-node->string)
+
 ; jq docs http://manpages.ubuntu.com/manpages/hirsute/man1/jq.1.html
 (defn execute
   "Given a JSON data string (1) and a JQ query string (2)

--- a/src/jq/api.clj
+++ b/src/jq/api.clj
@@ -16,7 +16,8 @@
    (impl/apply-json-query-on-string-data
      data
      (impl/compile-query query)
-     (impl/new-scope opts))))
+     (impl/new-scope opts)
+     (when (:multi opts) (impl/NewMultiOutputContainer)))))
 
 (defn processor
   "Given a JQ query string (1) compiles it and returns a function that given
@@ -27,7 +28,8 @@
    (let [^JsonQuery json-query (impl/compile-query query)
          ^Scope scope (impl/new-scope opts)]
      (fn ^String [^String data]
-       (impl/apply-json-query-on-string-data data json-query scope)))))
+       (impl/apply-json-query-on-string-data data json-query scope
+        (when (:multi opts) (impl/NewMultiOutputContainer)))))))
 
 (defn flexible-processor
   "Given a JQ query string (1) compiles it and returns a function that given
@@ -38,24 +40,25 @@
   ([^String query opts]
    (let [^JsonQuery query (impl/compile-query query)
          output-format (get opts :output :string)
-         ^Scope scope (impl/new-scope opts)]
+         ^Scope scope (impl/new-scope opts)
+         container (when (:multi opts) (impl/NewMultiOutputContainer))]
      (fn [json-data]
        (cond
          ; string => string
          (and (string? json-data) (= :string output-format))
-         (impl/apply-json-query-on-string-data json-data query scope)
+         (impl/apply-json-query-on-string-data json-data query scope container)
 
          ; string => json-node
          (and (string? json-data) (not= :string output-format))
-         (impl/apply-json-query-on-json-node (impl/string->json-node json-data) query scope)
+         (impl/apply-json-query-on-json-node (impl/string->json-node json-data) query scope container)
 
          ; json-node => string
          (and (not (string? json-data)) (= :string output-format))
-         (impl/apply-json-query-on-json-node-data json-data query scope)
+         (impl/apply-json-query-on-json-node-data json-data query scope container)
 
          ; json-node => json-node
          (and (not (string? json-data)) (not= :string output-format))
-         (impl/apply-json-query-on-json-node json-data query scope))))))
+         (impl/apply-json-query-on-json-node json-data query scope container))))))
 
 (comment
   (jq.api/execute "{\"a\":[1,2,3,4,5],\"b\":\"hello\"}" ".")

--- a/src/jq/api/api_impl.clj
+++ b/src/jq/api/api_impl.clj
@@ -3,6 +3,7 @@
   jq.api.api-impl
   (:import (net.thisptr.jackson.jq JsonQuery Versions Scope BuiltinFunctionLoader Output)
            (com.fasterxml.jackson.databind ObjectMapper JsonNode)
+           (com.fasterxml.jackson.databind.node JsonNodeFactory)
            (net.thisptr.jackson.jq.module.loaders ChainedModuleLoader BuiltinModuleLoader FileSystemModuleLoader)
            (net.thisptr.jackson.jq.module ModuleLoader)
            (java.nio.file Path)
@@ -59,25 +60,43 @@
      scope)))
 
 ; Helper interface that specifies a method to get a string value.
-(definterface IGetter
+(definterface IContainer
+  ; net.thisptr.jackson.jq/Output
   (^com.fasterxml.jackson.databind.JsonNode getValue []))
 
 ; Container class helper that implements the net.thisptr.jackson.jq.Output
 ; interface that enables the class to be used as a callback for JQ and exposes the
 ; unsynchronized-mutable container field for the result of the JQ transformation.
-(deftype OutputContainer [^:unsynchronized-mutable ^JsonNode container]
+(deftype SingleOutputContainer [^:unsynchronized-mutable ^JsonNode container]
   Output
   (emit [_ json-node] (set! container json-node))
-  IGetter
+  IContainer
   (getValue [_] container))
+
+(deftype MultiOutputContainer [seq-atom]
+  Output
+  (emit [_ json-node]
+    (swap! seq-atom conj json-node))
+  IContainer
+  (getValue [_]
+    (let [[contents _] (reset-vals! seq-atom [])
+          jsonArray (.arrayNode JsonNodeFactory/instance (count contents))]
+      (doseq [^JsonNode item contents]
+        (.add jsonArray item))
+      jsonArray)))
+
+(defn NewMultiOutputContainer []
+  (MultiOutputContainer. (atom [])))
 
 (defn apply-json-query-on-json-node
   "Given a JSON data string and a JsonQuery object applies the query
-  on the JSON data string and return JsonNode."
-  ^JsonNode [^JsonNode json-node ^JsonQuery json-query ^Scope scope]
-  (let [output-container (OutputContainer. nil)]
-    (.apply json-query (Scope/newChildScope scope) json-node output-container)
-    (.getValue output-container)))
+  on the JSON data string and return JsonNode; may be given a custom IContainer"
+  (^JsonNode [^JsonNode json-node ^JsonQuery json-query ^Scope scope ^IContainer output-container]
+    (let [^IContainer output-container (or output-container (SingleOutputContainer. nil))]
+      (.apply json-query (Scope/newChildScope scope) json-node output-container)
+      (.getValue output-container)))
+  (^JsonNode [^JsonNode json-node ^JsonQuery json-query ^Scope scope]
+    (apply-json-query-on-json-node json-node json-query scope nil)))
 
 (defn string->json-node ^JsonNode [^String data]
   (.readTree mapper data))
@@ -87,13 +106,13 @@
 
 (defn apply-json-query-on-string-data
   "Reads data JSON string into a JsonNode and passes to the query executor."
-  ^String [^String data ^JsonQuery query ^Scope scope]
-  (json-node->string (apply-json-query-on-json-node (string->json-node data) query scope)))
+  ^String [^String data ^JsonQuery query ^Scope scope ^IContainer output-container]
+  (json-node->string (apply-json-query-on-json-node (string->json-node data) query scope output-container)))
 
 (defn apply-json-query-on-json-node-data
   "Reads data JSON string into a JsonNode and passes to the query executor."
-  ^String [^JsonNode data ^JsonQuery query ^Scope scope]
-  (json-node->string (apply-json-query-on-json-node data query scope)))
+  ^String [^JsonNode data ^JsonQuery query ^Scope scope ^IContainer output-container]
+  (json-node->string (apply-json-query-on-json-node data query scope output-container)))
 
 (defn compile-query
   "Compiles a JQ query string into a JsonQuery object."

--- a/test/jq/api_test.clj
+++ b/test/jq/api_test.clj
@@ -41,6 +41,22 @@
       (is (string? resp))
       (is (= result-string resp)))))
 
+(deftest multi-output-execution
+  (testing "running a processor in multi-output mode, simple case"
+    (let [data-1 "[1,2,3]"
+          data-2 "[4,5,6]" ;; testing two calls ensures we aren't retaining extra state
+          script ".[] | {\"out\": .}"
+          processor-fn (jq/flexible-processor script {:output :string
+                                                      :multi true})]
+      (is (= "[{\"out\":1},{\"out\":2},{\"out\":3}]" (processor-fn data-1)))
+      (is (= "[{\"out\":4},{\"out\":5},{\"out\":6}]" (processor-fn data-2)))))
+  (testing "checking that queries can choose not to return any output given an input"
+    (let [data "[9,10,11]"
+          script ".[] | select(. >= 10)"
+          processor-fn (jq/flexible-processor script {:output :string
+                                                      :multi true})]
+      (is (= "[10,11]" (processor-fn data))))))
+
 (deftest string-to-string-execution
   (testing "mapping function onto values"
     (let [processor-fn (jq/processor query)]


### PR DESCRIPTION
Per #27. Implements a (slower) `MultiOutputContainer` that generates a JSON list of the query's results when given the active input, used when `:multi true` is set.