### PR TITLE
compile: pass through extra arguments to native-image

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
+: "${lib:=clj-jq}"
 
-if [ -z "$GRAALVM_HOME" ]; then
-    echo "Please set GRAALVM_HOME"
-    exit 1
-fi
+export JAVA_HOME=${GRAALVM_HOME?Please set GRAALVM_HOME}
+export PATH=$GRAALVM_HOME/bin:$PATH
 
 "$GRAALVM_HOME/bin/gu" install native-image || true
 
-export JAVA_HOME=$GRAALVM_HOME
-export PATH=$GRAALVM_HOME/bin:$PATH
+CLJ_JQ_VERSION=$(<resources/CLJ_JQ_VERSION)
 
-CLJ_JQ_VERSION=$(cat resources/CLJ_JQ_VERSION)
-
-args=( "-jar" "target/clj-jq-$CLJ_JQ_VERSION-standalone.jar"
-       "-H:Name=clj-jq"
+args=( "-jar" "target/$lib-$CLJ_JQ_VERSION-standalone.jar"
+       "-H:Name=$lib"
        "-H:+ReportExceptionStackTraces"
        "--initialize-at-build-time"
        "-H:Log=registerResource:"
@@ -28,4 +24,4 @@ if [ "$CLJ_JQ_STATIC" = "true" ]; then
     fi
 fi
 
-"$GRAALVM_HOME/bin/native-image" "${args[@]}"
+exec "$GRAALVM_HOME/bin/native-image" "${args[@]}" "$@"


### PR DESCRIPTION
...and other cleanups.

The argument-passthrough change (allowing things like `-H:-CheckToolchain` to be directly added to the command line passed to `compile`) is the primary motivator here, but doing some other cleanups while at it:

- Use `"$@"` to add all arguments to target command line
- Use `exec` so the shell is replaced with native-image in memory, allowing direct signal delivery
- Use `${var?error-if-unset}` syntax instead of multi-line check
- Use `$(<file)` instead of `$(cat file)` to perform the read operation internal to bash instead of spawning a separate `cat` executable

All of these changes should be compatible across all versions of bash in common use, inclusive of the (pre-GPLv3-relicense) bash 3.2 binaries shipped by Apple.