### PR TITLE
Add :vars to options to allow variables to be specified

### DIFF
--- a/src/jq/api/api_impl.clj
+++ b/src/jq/api/api_impl.clj
@@ -14,6 +14,11 @@
 
 (def jq-version Versions/JQ_1_6)
 
+(defn ->JsonNode ^JsonNode [data]
+  (if (instance? JsonNode data)
+    data
+    (.valueToTree mapper data)))
+
 (defn ->absolute-path
   "FileSystemModuleLoader requires absolute paths."
   ^Path [^String file-path]
@@ -96,7 +101,7 @@
        (setup-modules! scope module-paths))
      (when variables
        (doseq [[key value] variables]
-        (.setValue scope (name key) (if (string? value) (string->json-node value) value))))
+        (.setValue scope (name key) (->JsonNode value))))
      scope)))
 
 (defn compile-query

--- a/test/jq/api_test.clj
+++ b/test/jq/api_test.clj
@@ -2,12 +2,22 @@
   (:require [clojure.test :refer [deftest is testing]]
             [jq.api :as jq]
             [jq.api.api-impl :as utils])
-  (:import (com.fasterxml.jackson.databind JsonNode)))
+  (:import (com.fasterxml.jackson.databind JsonNode)
+           (com.fasterxml.jackson.databind.node JsonNodeFactory)))
 
 (def string-data "[1,2,3]")
 (def json-node-data (utils/string->json-node string-data))
 (def query "map(.+1)")
 (def result-string "[2,3,4]")
+
+(deftest variables
+  (testing "passing variables in at compile time"
+    (let [script "[$var1, $var2]"
+          processor-fn (jq/flexible-processor script {:output :string
+                                                      :vars {:var1 "\"hello\""
+                                                             "var2" (.textNode JsonNodeFactory/instance "world")}})
+          resp (processor-fn "null")]
+      (is (= resp "[\"hello\",\"world\"]")))))
 
 (deftest script-from-a-file
   (let [modules-dir "test/resources"

--- a/test/jq/api_test.clj
+++ b/test/jq/api_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [jq.api :as jq]
             [jq.api.api-impl :as utils])
-  (:import (com.fasterxml.jackson.databind JsonNode)
-           (com.fasterxml.jackson.databind.node JsonNodeFactory)))
+  (:import (com.fasterxml.jackson.databind JsonNode)))
 
 (def string-data "[1,2,3]")
 (def json-node-data (utils/string->json-node string-data))
@@ -12,12 +11,13 @@
 
 (deftest variables
   (testing "passing variables in at compile time"
-    (let [script "[$var1, $var2]"
+    (let [script "[$var1, $var2, $var3]"
           processor-fn (jq/flexible-processor script {:output :string
-                                                      :vars {:var1 "\"hello\""
-                                                             "var2" (.textNode JsonNodeFactory/instance "world")}})
+                                                      :vars {:var1 "hello"
+                                                             "var2" "world"
+                                                             :var3 123}})
           resp (processor-fn "null")]
-      (is (= resp "[\"hello\",\"world\"]")))))
+      (is (= resp "[\"hello\",\"world\",123]")))))
 
 (deftest script-from-a-file
   (let [modules-dir "test/resources"


### PR DESCRIPTION
Because this requires `string->json-node` to be defined before `new-scope`, the function gets moved down a bit.