### PR TITLE
flake.nix: make ''nix develop'' or ''nix-shell'' provide GNU make

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
     };
     devShells = {
       default = pkgs.mkShell {
-        buildInputs = with pkgs; [ clojure graalvm17-ce ] ++ [ cljpkgs.deps-lock ];
+        buildInputs = with pkgs; [ clojure gnumake graalvm17-ce ] ++ [ cljpkgs.deps-lock ];
         shellHook = ''
           PS1='[clj-jq] '"$PS1"
         '';


### PR DESCRIPTION
Previously, we depended on the user already having `make` installed independent of Nix.

With this change, we ensure that it's provided, just as we do clojure and graalvm, when running `nix-shell` or `nix develop` inside the clj-jq directory.