### PR TITLE
fix: handle string output with streams

### DIFF
--- a/cli/jq/cli.clj
+++ b/cli/jq/cli.clj
@@ -24,15 +24,14 @@
   (println summary))
 
 (defn execute [jq-filter files _]
-  (let [jq-processor (jq/flexible-processor jq-filter {:multi true, :output :json-node})]
+  (let [jq-processor (jq/flexible-processor jq-filter)]
     (if (seq files)
       (doseq [f files
               item (jq-processor (slurp f))]
         (println (jq/json-node->string item)))
       (when (.ready ^Reader *in*)
-        (doseq [line (line-seq (BufferedReader. *in*))
-                item (jq-processor line)]
-          (println (jq/json-node->string item)))))))
+        (doseq [^String line (line-seq (BufferedReader. *in*))]
+          (println (jq-processor line)))))))
 
 (defn -main [& args]
   (let [{:keys               [options arguments errors summary]

--- a/cli/jq/cli.clj
+++ b/cli/jq/cli.clj
@@ -24,16 +24,15 @@
   (println summary))
 
 (defn execute [jq-filter files _]
-  (let [jq-processor (jq/flexible-processor jq-filter)]
+  (let [jq-processor (jq/flexible-processor jq-filter {:output :json-node})]
     (if (seq files)
       (doseq [f files
               item (jq-processor (slurp f))]
         (println (jq/json-node->string item)))
       (when (.ready ^Reader *in*)
-        (doseq [^String line (line-seq (BufferedReader. *in*))]
-          (let [item (jq-processor line)]
-            (when-not (str/blank? item)
-              (println item))))))))
+        (doseq [^String line (line-seq (BufferedReader. *in*))
+                item (jq-processor line)]
+          (println (jq/json-node->string item)))))))
 
 (defn -main [& args]
   (let [{:keys               [options arguments errors summary]

--- a/cli/jq/cli.clj
+++ b/cli/jq/cli.clj
@@ -31,7 +31,9 @@
         (println (jq/json-node->string item)))
       (when (.ready ^Reader *in*)
         (doseq [^String line (line-seq (BufferedReader. *in*))]
-          (println (jq-processor line)))))))
+          (let [item (jq-processor line)]
+            (when-not (str/blank? item)
+              (println item))))))))
 
 (defn -main [& args]
   (let [{:keys               [options arguments errors summary]

--- a/src/jq/api.clj
+++ b/src/jq/api.clj
@@ -44,7 +44,7 @@
    (let [^JsonQuery query (impl/compile-query query)
          output-format (get opts :output :string)
          ^Scope scope (impl/new-scope opts)]
-     (fn [json-data]
+     (fn ^Iterable [json-data]
        (cond
          ; string => string
          (and (string? json-data) (= :string output-format))

--- a/src/jq/api.clj
+++ b/src/jq/api.clj
@@ -34,9 +34,6 @@
      (fn ^String [^String data]
        (impl/apply-json-query-on-string-data data json-query scope)))))
 
-(defn- container [opts]
-  (when (:multi opts) (impl/NewMultiOutputContainer)))
-
 (defn flexible-processor
   "Given a JQ query string (1) compiles it and returns a function that given
   a JsonNode object or a String (2) will return
@@ -46,8 +43,7 @@
   ([^String query opts]
    (let [^JsonQuery query (impl/compile-query query)
          output-format (get opts :output :string)
-         ^Scope scope (impl/new-scope opts)
-         container (container opts)]
+         ^Scope scope (impl/new-scope opts)]
      (fn [json-data]
        (cond
          ; string => string
@@ -56,15 +52,15 @@
 
          ; string => json-node
          (and (string? json-data) (not= :string output-format))
-         (impl/apply-json-query-on-json-node (impl/string->json-node json-data) query scope container)
+         (impl/apply-json-query-on-json-node (impl/string->json-node json-data) query scope)
 
          ; json-node => string
          (and (not (string? json-data)) (= :string output-format))
-         (impl/apply-json-query-on-json-node-data json-data query scope container)
+         (impl/apply-json-query-on-json-node-data json-data query scope)
 
          ; json-node => json-node
          (and (not (string? json-data)) (not= :string output-format))
-         (impl/apply-json-query-on-json-node json-data query scope container))))))
+         (impl/apply-json-query-on-json-node json-data query scope))))))
 
 (comment
   (jq.api/execute "{\"a\":[1,2,3,4,5],\"b\":\"hello\"}" ".")

--- a/src/jq/api.clj
+++ b/src/jq/api.clj
@@ -7,35 +7,35 @@
 ; required in common use cases, so moving out of impl space
 (def json-node->string impl/json-node->string)
 
-(defn- container [opts]
-  (when (:multi opts) (impl/NewMultiOutputContainer)))
-
 ; jq docs http://manpages.ubuntu.com/manpages/hirsute/man1/jq.1.html
 (defn execute
   "Given a JSON data string (1) and a JQ query string (2)
   returns a JSON string result of (2) applied on (1).
+  Output stream is joined with the new-line symbol.
   Accepts optional options map.
-  NOTE: if your query doesn't change the use the `processor`."
+  NOTE: if your query doesn't change then use the `processor`."
   (^String [^String data ^String query]
    (execute data query {}))
   (^String [^String data ^String query opts]
    (impl/apply-json-query-on-string-data
      data
      (impl/compile-query query)
-     (impl/new-scope opts)
-     (container opts))))
+     (impl/new-scope opts))))
 
 (defn processor
   "Given a JQ query string (1) compiles it and returns a function that given
   a JSON string (2) will return a JSON string with (1) applied on (2).
+  Output stream is joined with the new-line symbol.
   Accepts optional options map."
   ([^String query] (processor query {}))
   ([^String query opts]
    (let [^JsonQuery json-query (impl/compile-query query)
          ^Scope scope (impl/new-scope opts)]
      (fn ^String [^String data]
-       (impl/apply-json-query-on-string-data
-         data json-query scope (container opts))))))
+       (impl/apply-json-query-on-string-data data json-query scope)))))
+
+(defn- container [opts]
+  (when (:multi opts) (impl/NewMultiOutputContainer)))
 
 (defn flexible-processor
   "Given a JQ query string (1) compiles it and returns a function that given
@@ -52,7 +52,7 @@
        (cond
          ; string => string
          (and (string? json-data) (= :string output-format))
-         (impl/apply-json-query-on-string-data json-data query scope container)
+         (impl/apply-json-query-on-string-data json-data query scope)
 
          ; string => json-node
          (and (string? json-data) (not= :string output-format))

--- a/src/jq/api.clj
+++ b/src/jq/api.clj
@@ -44,7 +44,7 @@
    (let [^JsonQuery query (impl/compile-query query)
          output-format (get opts :output :string)
          ^Scope scope (impl/new-scope opts)]
-     (fn ^Iterable [json-data]
+     (fn [json-data]
        (cond
          ; string => string
          (and (string? json-data) (= :string output-format))

--- a/src/jq/api/api_impl.clj
+++ b/src/jq/api/api_impl.clj
@@ -2,8 +2,7 @@
       :no-doc true}
   jq.api.api-impl
   (:require [clojure.string :as str])
-  (:import (java.util ArrayList)
-           (net.thisptr.jackson.jq JsonQuery Versions Scope BuiltinFunctionLoader Output)
+  (:import (net.thisptr.jackson.jq JsonQuery Versions Scope BuiltinFunctionLoader Output)
            (com.fasterxml.jackson.databind ObjectMapper JsonNode)
            (com.fasterxml.jackson.databind.node ArrayNode JsonNodeFactory)
            (net.thisptr.jackson.jq.module.loaders ChainedModuleLoader BuiltinModuleLoader FileSystemModuleLoader)
@@ -76,12 +75,10 @@
 (defn apply-json-query-on-json-node
   "Given a JSON data string and a JsonQuery object applies the query
   on the JSON data string and return JsonNode; may be given a custom IContainer"
-  (^JsonNode [^JsonNode json-node ^JsonQuery json-query ^Scope scope ^IContainer output-container]
-    (let [^IContainer output-container (or output-container (NewMultiOutputContainer))]
-      (.apply json-query (Scope/newChildScope scope) json-node output-container)
-      (.getValue output-container)))
-  (^JsonNode [^JsonNode json-node ^JsonQuery json-query ^Scope scope]
-    (apply-json-query-on-json-node json-node json-query scope nil)))
+  ^JsonNode [^JsonNode json-node ^JsonQuery json-query ^Scope scope]
+  (let [^IContainer output-container (NewMultiOutputContainer)]
+    (.apply json-query (Scope/newChildScope scope) json-node output-container)
+    (.getValue output-container)))
 
 (defn string->json-node ^JsonNode [^String data]
   (.readTree mapper data))

--- a/src/jq/api/api_impl.clj
+++ b/src/jq/api/api_impl.clj
@@ -75,7 +75,7 @@
 (defn apply-json-query-on-json-node
   "Given a JSON data string and a JsonQuery object applies the query
   on the JSON data string and return JsonNode; may be given a custom IContainer"
-  ^JsonNode [^JsonNode json-node ^JsonQuery json-query ^Scope scope]
+  ^Iterable [^JsonNode json-node ^JsonQuery json-query ^Scope scope]
   (let [^IContainer output-container (NewMultiOutputContainer)]
     (.apply json-query (Scope/newChildScope scope) json-node output-container)
     (.getValue output-container)))
@@ -86,18 +86,16 @@
 (defn json-node->string ^String [^JsonNode data]
   (.writeValueAsString mapper data))
 
-(defn apply-json-query-on-string-data
-  "Reads data JSON string into a JsonNode and passes to the query executor."
-  ^String [^String data ^JsonQuery query ^Scope scope]
-  (let [stream (-> (string->json-node data)
-                   (apply-json-query-on-json-node query scope))]
-    (str/join "\n" (map json-node->string stream))))
-
 (defn apply-json-query-on-json-node-data
   "Passes a JsonNode to the query executor."
-  ^String [^JsonNode data ^JsonQuery query ^Scope scope]
+  ^Iterable [^JsonNode data ^JsonQuery query ^Scope scope]
   (let [stream (apply-json-query-on-json-node data query scope)]
-    (str/join "\n" (map json-node->string stream))))
+    (str/join "\n" (mapv json-node->string stream))))
+
+(defn apply-json-query-on-string-data
+  "Reads data JSON string into a JsonNode and passes to the query executor."
+  ^Iterable [^String data ^JsonQuery query ^Scope scope]
+  (apply-json-query-on-json-node-data (string->json-node data) query scope))
 
 (defn new-scope
   (^Scope [] (Scope/newChildScope root-scope))

--- a/test/jq/api_test.clj
+++ b/test/jq/api_test.clj
@@ -56,16 +56,14 @@
     (let [data-1 "[1,2,3]"
           data-2 "[4,5,6]" ;; testing two calls ensures we aren't retaining extra state
           script ".[] | {\"out\": .}"
-          processor-fn (jq/flexible-processor script {:output :string
-                                                      :multi true})]
-      (is (= "[{\"out\":1},{\"out\":2},{\"out\":3}]" (processor-fn data-1)))
-      (is (= "[{\"out\":4},{\"out\":5},{\"out\":6}]" (processor-fn data-2)))))
+          processor-fn (jq/flexible-processor script {:output :string})]
+      (is (= "{\"out\":1}\n{\"out\":2}\n{\"out\":3}" (processor-fn data-1)))
+      (is (= "{\"out\":4}\n{\"out\":5}\n{\"out\":6}" (processor-fn data-2)))))
   (testing "checking that queries can choose not to return any output given an input"
     (let [data "[9,10,11]"
           script ".[] | select(. >= 10)"
-          processor-fn (jq/flexible-processor script {:output :string
-                                                      :multi true})]
-      (is (= "[10,11]" (processor-fn data))))))
+          processor-fn (jq/flexible-processor script {:output :string})]
+      (is (= "10\n11" (processor-fn data))))))
 
 (deftest string-to-string-execution
   (testing "mapping function onto values"

--- a/test/jq/api_test.clj
+++ b/test/jq/api_test.clj
@@ -81,13 +81,15 @@
       (is (= result-string (processor-fn string-data)))))
 
   (testing "String to JsonNode"
-    (let [processor-fn (jq/flexible-processor query {:output :json-node})
+    (let [result-string "[[2,3,4]]"
+          processor-fn (jq/flexible-processor query {:output :json-node})
           resp (processor-fn string-data)]
       (is (instance? JsonNode resp))
       (is (= result-string (utils/json-node->string resp)))))
 
   (testing "JsonNode to JsonNode"
-    (let [processor-fn (jq/flexible-processor query {:output :json-node})
+    (let [result-string "[[2,3,4]]"
+          processor-fn (jq/flexible-processor query {:output :json-node})
           resp (processor-fn json-node-data)]
       (is (instance? JsonNode resp))
       (is (= result-string (utils/json-node->string resp)))))


### PR DESCRIPTION
This PR is a partial fix/hack for the cases when the jq script produces multiple outputs, e.g.
```shell
$ jq '.[]' <<<'[1,2,3]'
```
The problem was that this lib returned **only the last** emitted JSON entity.

In order not to introduce severe breaking changes, the following behavior is introduced:
1. For cases when the output is a string, multiple outputs are joined by a new line.
2. When `JsonNode` is expected the output is always `ArrayNode` which extends both `JsonNode` and `Iterable`.

With these changes, the types returned are the same as previously but values changed significantly in some cases (so the breaking changes are masquerading as "fixes"). The overall behavior ends up being "tricky". 
 
BREAKING CHANGES!

What's next:
- a new function that returns `Iterable` of `JsonNodes` #39
- Expose transducer interface #40