### PR TITLE
feat: avoid intermediate collection creation in transducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- Avoid creating intermediate collections in transducers #48
+
 ## v2.0.0
 
 - Upgrade `jackson-jq` to 1.0.0-preview.20230409 #26

--- a/src/jq/transducers.clj
+++ b/src/jq/transducers.clj
@@ -48,10 +48,9 @@
     :cat - whether to catenate output, default true"
   ([^String expression] (execute expression {}))
   ([^String expression opts]
-   (let [xf (map (api/stream-processor expression opts))]
-     (if (false? (:cat opts))
-       xf
-       (comp xf cat)))))
+   (if (false? (:cat opts))
+     (map (api/stream-processor expression opts))
+     (impl/fast-transducer expression opts))))
 
 (defn process
   "Returns a convenience transducer that:


### PR DESCRIPTION
Because less pressure on garbage collector and faster.

closes #47 