### PR TITLE
Fix/handle function not exist exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - Update GraalVM to 22.3.2
 - Update jackson-databind to 2.15.0
+- fix: only print the exception message
 
 ## v2.3.0
 

--- a/cli/jq/cli.clj
+++ b/cli/jq/cli.clj
@@ -48,5 +48,8 @@
       (if (:help options)
         (System/exit 0)
         (System/exit 1)))
-    (execute jq-filter files options))
+    (try
+      (execute jq-filter files options)
+      (catch Exception e
+        (.println System/err (.getMessage e)))))
   (System/exit 0))

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths
  ["src"]
  :deps
- {net.thisptr/jackson-jq {:mvn/version "1.0.0-preview.20230409"}
+ {net.thisptr/jackson-jq                      {:mvn/version "1.0.0-preview.20230409"}
   com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.15.0"}}
  :aliases
  {:dev


### PR DESCRIPTION
Previously:
```bash
✗ echo "1" | ./clj-jq '"%66%6f%6f" | uridecode' 
Exception in thread "main" net.thisptr.jackson.jq.exception.JsonQueryException: Function uridecode/0 does not exist
        at net.thisptr.jackson.jq.internal.tree.FunctionCall.lookupFunction(FunctionCall.java:49)
        at net.thisptr.jackson.jq.internal.tree.FunctionCall.apply(FunctionCall.java:55)
        at net.thisptr.jackson.jq.internal.tree.PipedQuery.pathRecursive(PipedQuery.java:52)
        at net.thisptr.jackson.jq.internal.tree.PipedQuery.lambda$pathRecursive$2(PipedQuery.java:53)
        at net.thisptr.jackson.jq.internal.tree.literal.ValueLiteral.apply(ValueLiteral.java:20)
        at net.thisptr.jackson.jq.internal.tree.PipedQuery.pathRecursive(PipedQuery.java:52)
        at net.thisptr.jackson.jq.internal.tree.PipedQuery.apply(PipedQuery.java:25)
        at net.thisptr.jackson.jq.internal.IsolatedScopeQuery.apply(IsolatedScopeQuery.java:21)
        at net.thisptr.jackson.jq.Expression.apply(Expression.java:11)
        at net.thisptr.jackson.jq.JsonQuery.apply(JsonQuery.java:17)
        at jq.api.api_impl$fast_transducer$fn__533$transducer__534.invoke(api_impl.clj:208)
        at jq.transducers$rdr__GT_json_nodes$fn__565$transducer__566.invoke(transducers.clj:42)
        at clojure.lang.PersistentVector.reduce(PersistentVector.java:343)
        at clojure.core$transduce.invokeStatic(core.clj:6946)
        at clojure.core$transduce.invoke(core.clj:6933)
        at jq.cli$execute.invokeStatic(cli.clj:37)
        at jq.cli$execute.invoke(cli.clj:30)
        at jq.cli$_main.invokeStatic(cli.clj:51)
        at jq.cli$_main.doInvoke(cli.clj:39)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at jq.cli.main(Unknown Source)
```

Now:
```bash
 ✗ echo "1" | clojure -M:cli -m jq.cli '"%66%6f%6f" | uridecode'
Function uridecode/0 does not exist
```