### PR TITLE
feat: add useful functions to the CLI tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Update GraalVM to 22.3.2
 - Update jackson-databind to 2.15.0
 - fix: only print the exception message
+- add `net.thisptr/jackson-jq-extra` package with useful functions to the CLI tool
 
 ## v2.3.0
 

--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,8 @@
    :jvm-opts   ["-Dclojure.main.report=stderr"]}
   :cli
   {:extra-paths ["cli" "classes" "resources"]
-   :extra-deps  {org.clojure/tools.cli {:mvn/version "1.0.219"}}}
+   :extra-deps  {org.clojure/tools.cli        {:mvn/version "1.0.219"}
+                 net.thisptr/jackson-jq-extra {:mvn/version "1.0.0-preview.20230409"}}}
   :build
   {:deps        {io.github.clojure/tools.build {:mvn/version "0.9.4"}}
    :extra-paths ["build"]


### PR DESCRIPTION
These functions now are [available](https://github.com/eiiches/jackson-jq/blob/develop/1.x/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/ModuleImpl.java):
```java
addFunction(new HostnameFunction());
addFunction(new RandomFunction());
addFunction(new StrFTimeFunction());
addFunction(new StrPTimeFunction());
addFunction(new TimestampFunction());
addFunction(new UriDecodeFunction());
addFunction(new UriParseFunction());
addFunction(new Uuid4Function()); 
```
